### PR TITLE
Fix cmake when compiling to a static lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,10 +64,10 @@ else()
 endif()
 if(BUILD_STATIC)
     add_library(qtadvanceddocking STATIC ${ads_SRCS})
-    set(ads_COMPILE_DEFINE ${ads_COMPILE_DEFINE} ADS_STATIC)
+    target_compile_definitions(qtadvanceddocking PUBLIC ADS_STATIC)
 else()
     add_library(qtadvanceddocking SHARED ${ads_SRCS})
-    set(ads_COMPILE_DEFINE ${ads_COMPILE_DEFINE} ADS_SHARED_EXPORT)
+    target_compile_definitions(qtadvanceddocking PUBLIC ADS_SHARED_EXPORT)
 endif()
 install(FILES ${ads_INSTALL_INCLUDE}
     DESTINATION include 


### PR DESCRIPTION
`ADS_STATIC` and `ADS_SHARED_EXPORT` are used in the public API and must therefore be `PUBLIC`. Currently the `ADS_EXPORT` macro is set to `Q_DECL_IMPORT` instead of being empty which makes it impossible to link statically.