### PR TITLE
Hide tab after viewToggled event

### DIFF
--- a/src/DockAreaTabBar.cpp
+++ b/src/DockAreaTabBar.cpp
@@ -525,8 +525,8 @@ void CDockAreaTabBar::closeTab(int Index)
 	{
 		return;
 	}
-	emit tabCloseRequested(Index);
 	Tab->hide();
+	emit tabCloseRequested(Index);
 }
 
 


### PR DESCRIPTION
This makes it possible to prevent the dock from closing by calling `CDockWidget::toggleView(true)` when `CDockWidget::closed` is emitted. Without this change, the tab would get hidden after the widget as been made visible again.